### PR TITLE
Use ICACHE_RAM_ATTR for interrupt handler

### DIFF
--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -67,7 +67,7 @@ int ESPiLight::nextPulseTrainLength() {
   return _pulseTrains[_avaiablePulseTrain].length;
 }
 
-void ESPiLight::interruptHandler() {
+void ICACHE_RAM_ATTR ESPiLight::interruptHandler() {
   if (!_enabledReceiver) {
     return;
   }


### PR DESCRIPTION
This attribute appears to be required in order to avoid crashes when using the WiFi at the same time as the interrupt handler is running.
See esp8266/Arduino#1388 for more details.