### PR TITLE
Define ICACHE_RAM_ATTR for ESP32

### DIFF
--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -16,6 +16,11 @@
   along with library. If not, see <http://www.gnu.org/licenses/>
 */
 
+// ESP32 doesn't define ICACHE_RAM_ATTR
+#ifndef ICACHE_RAM_ATTR
+#define ICACHE_RAM_ATTR IRAM_ATTR
+#endif
+
 #include <ESPiLight.h>
 
 extern "C" {


### PR DESCRIPTION
ICACHE_RAM_ATTR is not defined on ESP32 and prevent compiling on this platform.
Defining it to IRAM_ATTR resolves the problem.