### PR TITLE
Add method to limit the available protocols.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
 
 env:
   - PLATFORMIO_CI_SRC=tests/test_parse
+  - PLATFORMIO_CI_SRC=tests/test_proto_limit
   - PLATFORMIO_CI_SRC=examples/Receive
   - PLATFORMIO_CI_SRC=examples/Receive_Raw
   - PLATFORMIO_CI_SRC=examples/Transmit

--- a/src/ESPiLight.h
+++ b/src/ESPiLight.h
@@ -106,6 +106,14 @@ class ESPiLight {
    */
   static void interruptHandler();
 
+  /**
+   * Limit the available protocols.
+   *
+   * This gets a json array of the protocol names that should be activated.
+   * If the array is empty, the filter gets reset.
+   */
+  static void limitProtocols(const String &protos);
+
   static unsigned int minrawlen;
   static unsigned int maxrawlen;
   static unsigned int mingaplen;

--- a/tests/test_proto_limit/test_proto_limit.ino
+++ b/tests/test_proto_limit/test_proto_limit.ino
@@ -1,0 +1,78 @@
+/*
+ Basic ESPiLight protocol limiting
+
+ https://github.com/puuu/espilight
+*/
+
+#include <ESPiLight.h>
+
+#define PROTOCOL "elro_800_switch"
+#define JMESSAGE "{\"systemcode\":17,\"unitcode\":1,\"on\":1}"
+
+ESPiLight rf(-1);  // use -1 to disable transmitter
+
+// callback function. It is called on successfully received and parsed rc signal
+void rfCallback(const String &protocol, const String &message, int status,
+                int repeats, const String &deviceID) {
+  Serial.print("parsed message [");
+  Serial.print(protocol);  // protocoll used to parse
+  Serial.print("][");
+  Serial.print(deviceID);  // value of id key in json message
+  Serial.print("] (");
+  Serial.print(status);
+  Serial.print(") ");
+  Serial.print(message);  // message in json format
+  Serial.println();
+}
+
+void setup() {
+  Serial.begin(115200);
+  // set callback funktion
+  rf.setCallback(rfCallback);
+
+  int length = 0;
+  uint16_t pulses[MAXPULSESTREAMLENGTH];
+
+  // pulse train from ppilight json message
+  length = rf.createPulseTrain(pulses, PROTOCOL, JMESSAGE);
+
+  // parse pulse train multiple times
+  for (int i = 0; i < 5; i++) {
+    Serial.println();
+    Serial.print("Decoding turn ");
+    Serial.println(i);
+    Serial.println();
+    rf.parsePulseTrain(pulses, length);
+    delay(10);
+  }
+
+  // Limit the protocol
+  rf.limitProtocols("[\"" PROTOCOL "\"]");
+
+  // parse pulse train multiple times
+  for (int i = 0; i < 5; i++) {
+    Serial.println();
+    Serial.print("Decoding turn ");
+    Serial.println(i);
+    Serial.println();
+    rf.parsePulseTrain(pulses, length);
+    delay(10);
+  }
+
+  // Reset the filter
+  rf.limitProtocols("[]");
+
+  // parse pulse train multiple times
+  for (int i = 0; i < 5; i++) {
+    Serial.println();
+    Serial.print("Decoding turn ");
+    Serial.println(i);
+    Serial.println();
+    rf.parsePulseTrain(pulses, length);
+    delay(10);
+  }
+}
+
+void loop() {
+  // nothing
+}


### PR DESCRIPTION
This reduces the noise, as only the relevant protocols will be used for
parsing. It also saves performance, as for each sequence a smaller
amount of protocols needs to be validated.

This PR is based on PR #15 and part of the effort to split PR #14.
