### PR TITLE
Api changing cleanup

### DIFF
--- a/examples/Receive_Raw/Receive_Raw.ino
+++ b/examples/Receive_Raw/Receive_Raw.ino
@@ -12,7 +12,7 @@
 ESPiLight rf(TRANSMITTER_PIN);  // use -1 to disable transmitter
 
 // callback function. It is called on successfully received and parsed rc signal
-void rfRawCallback(const uint16_t* codes, int length) {
+void rfRawCallback(const uint16_t* codes, size_t length) {
   // print pulse lengths
   Serial.print("RAW signal: ");
   for (int i = 0; i < length; i++) {

--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -99,8 +99,8 @@ void ICACHE_RAM_ATTR ESPiLight::interruptHandler() {
     if (duration > MIN_PULSELENGTH) {
       if (duration < MAX_PULSELENGTH) {
         /* All codes are buffered */
-        codes[_nrpulses] = duration;
-        _nrpulses = (_nrpulses + 1) % MAXPULSESTREAMLENGTH;
+        codes[_nrpulses] = (uint16_t)duration;
+        _nrpulses = (uint8_t)((_nrpulses + 1) % MAXPULSESTREAMLENGTH);
         /* Let's match footers */
         if (duration > mingaplen) {
           // Debug('g');
@@ -385,14 +385,14 @@ String ESPiLight::pulseTrainToString(const uint16_t *codes, size_t length) {
       diff = (plstypes[x] / 50) - (codes[i] / 50);
       if ((diff >= -2) && (diff <= 2)) {
         /* Write numbers */
-        data += (char)('0' + ((char)x));
+        data += '0' + ((char)x);
         match = 1;
         break;
       }
     }
     if (match == 0) {
       plstypes[p++] = codes[i];
-      data += (char)('0' + ((char)(p - 1)));
+      data += '0' + ((char)(p - 1));
       if (p >= MAX_PULSE_TYPES) {
         DebugLn("too many pulse types");
         return String("");

--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -271,8 +271,8 @@ int ESPiLight::createPulseTrain(uint16_t *pulses, const String &protocol_id,
   return 0;
 }
 
-int ESPiLight::parsePulseTrain(uint16_t *pulses, uint8_t length) {
-  int matches = 0;
+size_t ESPiLight::parsePulseTrain(uint16_t *pulses, uint8_t length) {
+  size_t matches = 0;
   protocol_t *protocol = nullptr;
   protocols_t *pnode = used_protocols;
 

--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -360,7 +360,7 @@ static void fire_callback(protocol_t *protocol, ESPiLightCallBack callback) {
              protocol->repeats, deviceId);
 }
 
-String ESPiLight::pulseTrainToString(const uint16_t *codes, int length) {
+String ESPiLight::pulseTrainToString(const uint16_t *codes, size_t length) {
   int i = 0, x = 0, match = 0;
   int diff = 0;
   int plstypes[MAX_PULSE_TYPES];

--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -411,10 +411,12 @@ String ESPiLight::pulseTrainToString(const uint16_t *codes, size_t length) {
 }
 
 int ESPiLight::stringToPulseTrain(const String &data, uint16_t *codes,
-                                  int maxlength) {
-  int start = 0, end = 0, pulse_index;
+                                  size_t maxlength) {
+  unsigned int start = 0;
+  int end = 0;
+  int pulse_index;
   unsigned int i = 0;
-  int plstypes[MAX_PULSE_TYPES];
+  uint16_t plstypes[MAX_PULSE_TYPES];
 
   for (i = 0; i < MAX_PULSE_TYPES; i++) {
     plstypes[i] = 0;
@@ -424,12 +426,13 @@ int ESPiLight::stringToPulseTrain(const String &data, uint16_t *codes,
   int spulse = data.indexOf('p') + 2;
   if (scode > 0 && (unsigned)scode < data.length() && spulse > 0 &&
       (unsigned)spulse < data.length()) {
-    int nrpulses = 0;
-    start = spulse;
+    unsigned int nrpulses = 0;
+    start = (unsigned)spulse;
     end = data.indexOf(',', start);
     while (end > 0) {
-      plstypes[nrpulses++] = data.substring(start, end).toInt();
-      start = end + 1;
+      plstypes[nrpulses++] =
+          (uint16_t)data.substring(start, (unsigned)end).toInt();
+      start = (unsigned)end + 1;
       end = data.indexOf(',', start);
     }
     end = data.indexOf(';', start);
@@ -439,12 +442,13 @@ int ESPiLight::stringToPulseTrain(const String &data, uint16_t *codes,
     if (end < 0) {
       return -2;
     }
-    plstypes[nrpulses++] = data.substring(start, end).toInt();
+    plstypes[nrpulses++] =
+        (uint16_t)data.substring(start, (unsigned)end).toInt();
 
-    int codelen = 0;
-    for (i = scode; i < data.length(); i++) {
+    unsigned int codelen = 0;
+    for (i = (unsigned)scode; i < data.length(); i++) {
       if ((data[i] == ';') || (data[i] == '@')) break;
-      if (i >= (unsigned)maxlength) break;
+      if (i >= maxlength) break;
       pulse_index = data[i] - '0';
       if ((pulse_index < 0) || (pulse_index >= nrpulses)) return -3;
       codes[codelen++] = plstypes[pulse_index];

--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -63,9 +63,9 @@ void ESPiLight::initReceiver(byte inputPin) {
   }
 }
 
-int ESPiLight::receivePulseTrain(uint16_t *pulses) {
-  int i = 0;
-  int length = nextPulseTrainLength();
+uint8_t ESPiLight::receivePulseTrain(uint16_t *pulses) {
+  uint8_t i = 0;
+  uint8_t length = nextPulseTrainLength();
 
   if (length > 0) {
     volatile PulseTrain_t &pulseTrain = _pulseTrains[_avaiablePulseTrain];
@@ -78,7 +78,7 @@ int ESPiLight::receivePulseTrain(uint16_t *pulses) {
   return length;
 }
 
-int ESPiLight::nextPulseTrainLength() {
+uint8_t ESPiLight::nextPulseTrainLength() {
   return _pulseTrains[_avaiablePulseTrain].length;
 }
 
@@ -135,7 +135,7 @@ void ESPiLight::enableReceiver() { _enabledReceiver = true; }
 void ESPiLight::disableReceiver() { _enabledReceiver = false; }
 
 void ESPiLight::loop() {
-  int length = 0;
+  uint8_t length = 0;
   uint16_t pulses[MAXPULSESTREAMLENGTH];
 
   length = receivePulseTrain(pulses);
@@ -271,7 +271,7 @@ int ESPiLight::createPulseTrain(uint16_t *pulses, const String &protocol_id,
   return 0;
 }
 
-int ESPiLight::parsePulseTrain(uint16_t *pulses, int length) {
+int ESPiLight::parsePulseTrain(uint16_t *pulses, uint8_t length) {
   int matches = 0;
   protocol_t *protocol = nullptr;
   protocols_t *pnode = used_protocols;

--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -45,10 +45,10 @@ volatile unsigned long ESPiLight::_lastChange =
     0;  // Timestamp of previous edge
 volatile uint8_t ESPiLight::_nrpulses = 0;
 
-unsigned int ESPiLight::minrawlen = 5;
-unsigned int ESPiLight::maxrawlen = MAXPULSESTREAMLENGTH;
-unsigned int ESPiLight::mingaplen = 5100;
-unsigned int ESPiLight::maxgaplen = 10000;
+uint8_t ESPiLight::minrawlen = 5;
+uint8_t ESPiLight::maxrawlen = MAXPULSESTREAMLENGTH;
+uint16_t ESPiLight::mingaplen = 5100;
+uint16_t ESPiLight::maxgaplen = 10000;
 
 static void fire_callback(protocol_t *protocol, ESPiLightCallBack callback);
 

--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -59,7 +59,7 @@ void ESPiLight::initReceiver(byte inputPin) {
   enableReceiver();
 
   if (interrupt >= 0) {
-    attachInterrupt(interrupt, interruptHandler, CHANGE);
+    attachInterrupt(static_cast<uint8_t>(interrupt), interruptHandler, CHANGE);
   }
 }
 

--- a/src/ESPiLight.h
+++ b/src/ESPiLight.h
@@ -61,7 +61,7 @@ class ESPiLight {
   /**
    * Parse pulse train and fire callback
    */
-  int parsePulseTrain(uint16_t *pulses, uint8_t length);
+  size_t parsePulseTrain(uint16_t *pulses, uint8_t length);
 
   /**
    * Process receiver queue and fire callback

--- a/src/ESPiLight.h
+++ b/src/ESPiLight.h
@@ -39,7 +39,7 @@ typedef struct PulseTrain_t {
 typedef void (*ESPiLightCallBack)(const String &protocol, const String &message,
                                   int status, int repeats,
                                   const String &deviceID);
-typedef void (*PulseTrainCallBack)(const uint16_t *pulses, int length);
+typedef void (*PulseTrainCallBack)(const uint16_t *pulses, size_t length);
 
 class ESPiLight {
  public:
@@ -61,7 +61,7 @@ class ESPiLight {
   /**
    * Parse pulse train and fire callback
    */
-  int parsePulseTrain(uint16_t *pulses, int length);
+  int parsePulseTrain(uint16_t *pulses, uint8_t length);
 
   /**
    * Process receiver queue and fire callback
@@ -80,13 +80,13 @@ class ESPiLight {
    * Get last received PulseTrain.
    * Returns: length of PulseTrain or 0 if not avaiable
    */
-  static int receivePulseTrain(uint16_t *pulses);
+  static uint8_t receivePulseTrain(uint16_t *pulses);
 
   /**
    * Check if new PulseTrain avaiable.
    * Returns: 0 if no new PulseTrain avaiable
    */
-  static int nextPulseTrainLength();
+  static uint8_t nextPulseTrainLength();
 
   /**
    * Enable Receiver. No need to call enableReceiver() after initReceiver().

--- a/src/ESPiLight.h
+++ b/src/ESPiLight.h
@@ -114,10 +114,10 @@ class ESPiLight {
    */
   static void limitProtocols(const String &protos);
 
-  static unsigned int minrawlen;
-  static unsigned int maxrawlen;
-  static unsigned int mingaplen;
-  static unsigned int maxgaplen;
+  static uint8_t minrawlen;
+  static uint8_t maxrawlen;
+  static uint16_t mingaplen;
+  static uint16_t maxgaplen;
 
   static String pulseTrainToString(const uint16_t *pulses, int length);
   static int stringToPulseTrain(const String &data, uint16_t *pulses,

--- a/src/ESPiLight.h
+++ b/src/ESPiLight.h
@@ -121,7 +121,7 @@ class ESPiLight {
 
   static String pulseTrainToString(const uint16_t *pulses, size_t length);
   static int stringToPulseTrain(const String &data, uint16_t *pulses,
-                                int maxlength);
+                                size_t maxlength);
 
   static int createPulseTrain(uint16_t *pulses, const String &protocol_id,
                               const String &json);

--- a/src/ESPiLight.h
+++ b/src/ESPiLight.h
@@ -119,7 +119,7 @@ class ESPiLight {
   static uint16_t mingaplen;
   static uint16_t maxgaplen;
 
-  static String pulseTrainToString(const uint16_t *pulses, int length);
+  static String pulseTrainToString(const uint16_t *pulses, size_t length);
   static int stringToPulseTrain(const String &data, uint16_t *pulses,
                                 int maxlength);
 

--- a/tests/test_parse/test_parse.ino
+++ b/tests/test_parse/test_parse.ino
@@ -12,7 +12,7 @@
 ESPiLight rf(-1);  // use -1 to disable transmitter
 
 // callback function. It is called on successfully received and parsed rc signal
-void rfRawCallback(const uint16_t *codes, int length) {
+void rfRawCallback(const uint16_t *codes, size_t length) {
   // print pulse lengths
   printPulseTrain(codes, length);
 


### PR DESCRIPTION
This contains all the changes that might affect the external API. The only real impact in the tests was seen in the pulse-train-callback. Users of this feature have to change the signature that the length of the train is an `uint8_t` which should have no impact at all, as this was always an `uint8_t` that got casted to an `int` somewhere.

This is part of the effort to split #14 and is based on #18 .