### PR TITLE
Add simple testcase for protocol filtering.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
 
 env:
   - PLATFORMIO_CI_SRC=tests/test_parse
+  - PLATFORMIO_CI_SRC=tests/test_proto_limit
   - PLATFORMIO_CI_SRC=examples/Receive
   - PLATFORMIO_CI_SRC=examples/Receive_Raw
   - PLATFORMIO_CI_SRC=examples/Transmit

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ branch. The `release` is used to integrate the pilight files and for
 version tagging, like necessary for the Arduino Library Manager
 crawler.
 
+To prevent formating issues, please make sure that your code is proper
+formatted. We use the `clang-format` tool with the `Google` style.
+You can just format the code by calling
+```
+$ clang-format -style=Google -i <source-file>
+```
+
 
 ### Install from source
 

--- a/examples/Receive_Raw/Receive_Raw.ino
+++ b/examples/Receive_Raw/Receive_Raw.ino
@@ -12,7 +12,7 @@
 ESPiLight rf(TRANSMITTER_PIN);  //use -1 to disable transmitter
 
 // callback function. It is called on successfully received and parsed rc signal
-void rfRawCallback(const uint16_t* codes, int length) {
+void rfRawCallback(const uint16_t* codes, uint8_t length) {
   // print pulse lengths
   Serial.print("RAW signal: ");
   for(int i=0; i < length; i++) {

--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -114,7 +114,6 @@ void ICACHE_RAM_ATTR ESPiLight::interruptHandler() {
   } else {
     Debug("_!_");
   }
-  return;
 }
 
 void ESPiLight::resetReceiver() {
@@ -210,7 +209,6 @@ void ESPiLight::sendPulseTrain(const uint16_t *pulses, int length,
     digitalWrite(_outputPin, LOW);
     // if (receiverState) enableReceiver();
   }
-  return;
 }
 
 int ESPiLight::send(const String &protocol, const String &json, int repeats) {

--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -241,7 +241,7 @@ int ESPiLight::createPulseTrain(uint16_t *pulses, const String &protocol_id,
 
   Debug("piLightCreatePulseTrain: ");
 
-  if (json_validate(content.c_str()) != true) {
+  if (!json_validate(content.c_str())) {
     Debug("invalid json: ");
     DebugLn(content);
     return -2;

--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -54,7 +54,7 @@ void ESPiLight::initReceiver(byte inputPin) {
   enableReceiver();
 
   if (interrupt >= 0) {
-    attachInterrupt(interrupt, interruptHandler, CHANGE);
+    attachInterrupt(static_cast<uint8_t>(interrupt), interruptHandler, CHANGE);
   }
 }
 

--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -370,7 +370,8 @@ static void fire_callback(protocol_t *protocol, ESPiLightCallBack callback) {
              protocol->repeats, deviceId);
 }
 
-String ESPiLight::pulseTrainToString(const uint16_t *codes, int length) {
+String ESPiLight::pulseTrainToString(const uint16_t *codes,
+                                     unsigned int length) {
   int i = 0, x = 0, match = 0;
   int diff = 0;
   int plstypes[MAX_PULSE_TYPES];

--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -156,8 +156,8 @@ ESPiLight::ESPiLight(int8_t outputPin) {
   _rawCallback = nullptr;
 
   if (_outputPin >= 0) {
-    pinMode(_outputPin, OUTPUT);
-    digitalWrite(_outputPin, LOW);
+    pinMode(static_cast<uint8_t>(_outputPin), OUTPUT);
+    digitalWrite(static_cast<uint8_t>(_outputPin), LOW);
   }
 
   if (protocols == nullptr) {
@@ -198,15 +198,15 @@ void ESPiLight::sendPulseTrain(const uint16_t *pulses, int length,
     // disableReceiver()
     for (r = 0; r < repeats; r++) {
       for (x = 0; x < length; x += 2) {
-        digitalWrite(_outputPin, HIGH);
+        digitalWrite(static_cast<uint8_t>(_outputPin), HIGH);
         delayMicroseconds(pulses[x]);
-        digitalWrite(_outputPin, LOW);
+        digitalWrite(static_cast<uint8_t>(_outputPin), LOW);
         if (x + 1 < length) {
           delayMicroseconds(pulses[x + 1]);
         }
       }
     }
-    digitalWrite(_outputPin, LOW);
+    digitalWrite(static_cast<uint8_t>(_outputPin), LOW);
     // if (receiverState) enableReceiver();
   }
 }

--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -212,6 +212,10 @@ void ESPiLight::sendPulseTrain(const uint16_t *pulses, int length,
 }
 
 int ESPiLight::send(const String &protocol, const String &json, int repeats) {
+  if (_outputPin < 0) {
+    DebugLn("No output pin set, cannot send");
+    return -1;
+  }
   int length = 0;
   uint16_t pulses[MAXPULSESTREAMLENGTH];
 

--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -422,10 +422,12 @@ String ESPiLight::pulseTrainToString(const uint16_t *codes,
 }
 
 int ESPiLight::stringToPulseTrain(const String &data, uint16_t *codes,
-                                  int maxlength) {
-  int start = 0, end = 0, pulse_index;
+                                  unsigned int maxlength) {
+  unsigned int start = 0;
+  int end = 0;
+  int pulse_index;
   unsigned int i = 0;
-  int plstypes[MAX_PULSE_TYPES];
+  uint16_t plstypes[MAX_PULSE_TYPES];
 
   for (i = 0; i < MAX_PULSE_TYPES; i++) {
     plstypes[i] = 0;
@@ -435,23 +437,25 @@ int ESPiLight::stringToPulseTrain(const String &data, uint16_t *codes,
   int spulse = data.indexOf('p') + 2;
   if (scode > 0 && (unsigned)scode < data.length() && spulse > 0 &&
       (unsigned)spulse < data.length()) {
-    int nrpulses = 0;
-    start = spulse;
+    unsigned int nrpulses = 0;
+    start = (unsigned)spulse;
     end = data.indexOf(',', start);
     while (end > 0) {
-      plstypes[nrpulses++] = data.substring(start, end).toInt();
-      start = end + 1;
+      plstypes[nrpulses++] =
+          (uint16_t)data.substring(start, (unsigned)end).toInt();
+      start = (unsigned)end + 1;
       end = data.indexOf(',', start);
     }
     end = data.indexOf(';', start);
     if (end < 0) end = data.indexOf('@', start);
     if (end < 0) return -2;
-    plstypes[nrpulses++] = data.substring(start, end).toInt();
+    plstypes[nrpulses++] =
+        (uint16_t)data.substring(start, (unsigned)end).toInt();
 
-    int codelen = 0;
-    for (i = scode; i < data.length(); i++) {
+    unsigned int codelen = 0;
+    for (i = (unsigned)scode; i < data.length(); i++) {
       if ((data[i] == ';') || (data[i] == '@')) break;
-      if (i >= (unsigned)maxlength) break;
+      if (i >= maxlength) break;
       pulse_index = data[i] - '0';
       if ((pulse_index < 0) || (pulse_index >= nrpulses)) return -3;
       codes[codelen++] = plstypes[pulse_index];

--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -19,7 +19,7 @@
 #include <ESPiLight.h>
 
 extern "C" {
-  #include "pilight/libs/pilight/protocols/protocol.h"
+#include "pilight/libs/pilight/protocols/protocol.h"
 }
 struct protocols_t *protocols = NULL;
 
@@ -27,7 +27,8 @@ volatile PulseTrain_t ESPiLight::_pulseTrains[RECEIVER_BUFFER_SIZE];
 boolean ESPiLight::_enabledReceiver;
 volatile int ESPiLight::_actualPulseTrain = 0;
 int ESPiLight::_avaiablePulseTrain = 0;
-volatile unsigned long ESPiLight::_lastChange = 0; // Timestamp of previous edge
+volatile unsigned long ESPiLight::_lastChange =
+    0;  // Timestamp of previous edge
 volatile uint8_t ESPiLight::_nrpulses = 0;
 
 unsigned int ESPiLight::minrawlen = 5;
@@ -52,10 +53,10 @@ int ESPiLight::receivePulseTrain(uint16_t *pulses) {
   int i = 0;
   int length = nextPulseTrainLength();
 
-  if(length > 0) {
+  if (length > 0) {
     volatile PulseTrain_t &pulseTrain = _pulseTrains[_avaiablePulseTrain];
-    _avaiablePulseTrain = (_avaiablePulseTrain + 1)%RECEIVER_BUFFER_SIZE;
-    for(i=0;i<length;i++) {
+    _avaiablePulseTrain = (_avaiablePulseTrain + 1) % RECEIVER_BUFFER_SIZE;
+    for (i = 0; i < length; i++) {
       pulses[i] = pulseTrain.pulses[i];
     }
     pulseTrain.length = 0;
@@ -78,31 +79,30 @@ void ICACHE_RAM_ATTR ESPiLight::interruptHandler() {
   volatile PulseTrain_t &pulseTrain = _pulseTrains[_actualPulseTrain];
   volatile uint16_t *codes = pulseTrain.pulses;
 
-  if(pulseTrain.length == 0) {
+  if (pulseTrain.length == 0) {
     duration = now - _lastChange;
     /* We first do some filtering (same as pilight BPF) */
-    if(duration > MIN_PULSELENGTH) {
-      if(duration < MAX_PULSELENGTH) {
-	/* All codes are buffered */
-	codes[_nrpulses] = duration;
-	_nrpulses = (_nrpulses+1)%MAXPULSESTREAMLENGTH;
-	/* Let's match footers */
-	if(duration > mingaplen) {
-	  //Serial.print('g');
-	  /* Only match minimal length pulse streams */
-	  if(_nrpulses >= minrawlen && _nrpulses <= maxrawlen) {
-	    //Serial.print(_nrpulses);
-	    //Serial.print('l');
-	    pulseTrain.length = _nrpulses;
-	    _actualPulseTrain = (_actualPulseTrain + 1)%RECEIVER_BUFFER_SIZE;
-	  }
-	  _nrpulses = 0;
-	}
+    if (duration > MIN_PULSELENGTH) {
+      if (duration < MAX_PULSELENGTH) {
+        /* All codes are buffered */
+        codes[_nrpulses] = duration;
+        _nrpulses = (_nrpulses + 1) % MAXPULSESTREAMLENGTH;
+        /* Let's match footers */
+        if (duration > mingaplen) {
+          // Serial.print('g');
+          /* Only match minimal length pulse streams */
+          if (_nrpulses >= minrawlen && _nrpulses <= maxrawlen) {
+            // Serial.print(_nrpulses);
+            // Serial.print('l');
+            pulseTrain.length = _nrpulses;
+            _actualPulseTrain = (_actualPulseTrain + 1) % RECEIVER_BUFFER_SIZE;
+          }
+          _nrpulses = 0;
+        }
       }
       _lastChange = now;
     }
-  }
-  else {
+  } else {
     Serial.print("_!_");
   }
   return;
@@ -110,20 +110,16 @@ void ICACHE_RAM_ATTR ESPiLight::interruptHandler() {
 
 void ESPiLight::resetReceiver() {
   int i = 0;
-  for(i=0;i<RECEIVER_BUFFER_SIZE;i++) {
+  for (i = 0; i < RECEIVER_BUFFER_SIZE; i++) {
     _pulseTrains[i].length = 0;
   }
   _actualPulseTrain = 0;
   _nrpulses = 0;
 }
 
-void ESPiLight::enableReceiver() {
-  _enabledReceiver = true;
-}
+void ESPiLight::enableReceiver() { _enabledReceiver = true; }
 
-void ESPiLight::disableReceiver() {
-  _enabledReceiver = false;
-}
+void ESPiLight::disableReceiver() { _enabledReceiver = false; }
 
 void ESPiLight::loop() {
   int length = 0;
@@ -131,7 +127,7 @@ void ESPiLight::loop() {
 
   length = receivePulseTrain(pulses);
 
-  if(length > 0) {
+  if (length > 0) {
     /*
     Serial.print("RAW (");
     Serial.print(length);
@@ -151,7 +147,7 @@ ESPiLight::ESPiLight(int8_t outputPin) {
   _callback = NULL;
   _rawCallback = NULL;
 
-  if(_outputPin >= 0) {
+  if (_outputPin >= 0) {
     pinMode(_outputPin, OUTPUT);
     digitalWrite(_outputPin, LOW);
   }
@@ -167,23 +163,24 @@ void ESPiLight::setPulseTrainCallBack(PulseTrainCallBack rawCallback) {
   _rawCallback = rawCallback;
 }
 
-void ESPiLight::sendPulseTrain(const uint16_t *pulses, int length, int repeats) {
-  //boolean receiverState = _enabledReceiver;
+void ESPiLight::sendPulseTrain(const uint16_t *pulses, int length,
+                               int repeats) {
+  // boolean receiverState = _enabledReceiver;
   int r = 0, x = 0;
-  if(_outputPin >= 0) {
-    //disableReceiver()
-    for(r=0;r<repeats;r++) {
-      for(x=0;x<length;x+=2) {
-	digitalWrite(_outputPin, HIGH);
-	delayMicroseconds(pulses[x]);
-	digitalWrite(_outputPin, LOW);
-	if(x+1 < length) {
-	  delayMicroseconds(pulses[x+1]);
-	}
+  if (_outputPin >= 0) {
+    // disableReceiver()
+    for (r = 0; r < repeats; r++) {
+      for (x = 0; x < length; x += 2) {
+        digitalWrite(_outputPin, HIGH);
+        delayMicroseconds(pulses[x]);
+        digitalWrite(_outputPin, LOW);
+        if (x + 1 < length) {
+          delayMicroseconds(pulses[x + 1]);
+        }
       }
     }
     digitalWrite(_outputPin, LOW);
-    //if (receiverState) enableReceiver();
+    // if (receiverState) enableReceiver();
   }
   return;
 }
@@ -193,7 +190,7 @@ int ESPiLight::send(const String &protocol, const String &json, int repeats) {
   uint16_t pulses[MAXPULSESTREAMLENGTH];
 
   length = createPulseTrain(pulses, protocol, json);
-  if(length > 0) {
+  if (length > 0) {
     /*
     Serial.println();
     Serial.print("send: ");
@@ -210,7 +207,7 @@ int ESPiLight::send(const String &protocol, const String &json, int repeats) {
 }
 
 int ESPiLight::createPulseTrain(uint16_t *pulses, const String &protocol_id,
-				const String &content) {
+                                const String &content) {
   struct protocol_t *protocol = NULL;
   struct protocols_t *pnode = protocols;
   int return_value = EXIT_FAILURE;
@@ -218,19 +215,17 @@ int ESPiLight::createPulseTrain(uint16_t *pulses, const String &protocol_id,
 
   Serial.print("piLightCreatePulseTrain: ");
 
-  if(json_validate(content.c_str()) != true) {
+  if (json_validate(content.c_str()) != true) {
     Serial.print("invalid json: ");
     Serial.println(content);
     return -2;
   }
 
-  while(pnode != NULL) {
+  while (pnode != NULL) {
     protocol = pnode->listener;
 
-    if((protocol->createCode != NULL)
-       && (protocol_id == protocol->id)
-       && (protocol->maxrawlen <= MAXPULSESTREAMLENGTH)) {
-
+    if ((protocol->createCode != NULL) && (protocol_id == protocol->id) &&
+        (protocol->maxrawlen <= MAXPULSESTREAMLENGTH)) {
       Serial.print("protocol: ");
       Serial.print(protocol->id);
 
@@ -244,12 +239,11 @@ int ESPiLight::createPulseTrain(uint16_t *pulses, const String &protocol_id,
       protocol->message = NULL;
 
       if (return_value == EXIT_SUCCESS) {
-	Serial.println(" create Code succeded.");
-	return protocol->rawlen;
-      }
-      else {
-	Serial.println(" create Code failed.");
-	return -1;
+        Serial.println(" create Code succeded.");
+        return protocol->rawlen;
+      } else {
+        Serial.println(" create Code failed.");
+        return -1;
       }
     }
     pnode = pnode->next;
@@ -262,46 +256,44 @@ int ESPiLight::parsePulseTrain(uint16_t *pulses, int length) {
   struct protocol_t *protocol = NULL;
   struct protocols_t *pnode = protocols;
 
-  //Serial.println("piLightParsePulseTrain start");
-  while((pnode != NULL) && (_callback != NULL) ) {
+  // Serial.println("piLightParsePulseTrain start");
+  while ((pnode != NULL) && (_callback != NULL)) {
     protocol = pnode->listener;
 
-    if(protocol->parseCode != NULL && protocol->validate != NULL) {
-
+    if (protocol->parseCode != NULL && protocol->validate != NULL) {
       protocol->raw = pulses;
       protocol->rawlen = length;
 
-      if(protocol->validate() == 0) {
+      if (protocol->validate() == 0) {
+        Serial.print("pulses: ");
+        Serial.print(length);
+        Serial.print(" possible protocol: ");
+        Serial.println(protocol->id);
 
-	Serial.print("pulses: ");
-	Serial.print(length);
-	Serial.print(" possible protocol: ");
-	Serial.println(protocol->id);
+        if (protocol->first > 0) {
+          protocol->first = protocol->second;
+        }
+        protocol->second = micros();
+        if (protocol->first == 0) {
+          protocol->first = protocol->second;
+        }
 
-	if(protocol->first > 0) {
-	  protocol->first = protocol->second;
-	}
-	protocol->second = micros();
-	if(protocol->first == 0) {
-	  protocol->first = protocol->second;
-	}
+        /* Reset # of repeats after a certain delay */
+        if (((int)protocol->second - (int)protocol->first) > 500000) {
+          protocol->repeats = 0;
+        }
 
-	/* Reset # of repeats after a certain delay */
-	if(((int)protocol->second-(int)protocol->first) > 500000) {
-	  protocol->repeats = 0;
-	}
+        protocol->message = NULL;
+        protocol->parseCode();
+        if (protocol->message != NULL) {
+          matches++;
+          protocol->repeats++;
 
-	protocol->message = NULL;
-	protocol->parseCode();
-	if (protocol->message != NULL) {
-	  matches++;
-	  protocol->repeats++;
+          fire_callback(protocol, _callback);
 
-	  fire_callback(protocol, _callback);
-
-	  json_delete(protocol->message);
-	  protocol->message = NULL;
-	}
+          json_delete(protocol->message);
+          protocol->message = NULL;
+        }
       }
     }
     pnode = pnode->next;
@@ -310,8 +302,8 @@ int ESPiLight::parsePulseTrain(uint16_t *pulses, int length) {
     (_rawCallback)(pulses, length);
   }
 
-  //Serial.print("piLightParsePulseTrain end. matches: ");
-  //Serial.println(matches);
+  // Serial.print("piLightParsePulseTrain end. matches: ");
+  // Serial.println(matches);
   return matches;
 }
 
@@ -322,39 +314,35 @@ static void fire_callback(protocol_t *protocol, ESPiLightCallBack callback) {
   double itmp;
   char *stmp;
 
-  if((protocol->repeats <= 1) || (protocol->old_content == NULL)) {
+  if ((protocol->repeats <= 1) || (protocol->old_content == NULL)) {
     status = FIRST;
     json_free(protocol->old_content);
     protocol->old_content = content;
-  }
-  else if(protocol->repeats < 100) {
-    if(strcmp(content, protocol->old_content) == 0) {
+  } else if (protocol->repeats < 100) {
+    if (strcmp(content, protocol->old_content) == 0) {
       protocol->repeats += 100;
       status = VALID;
-    }
-    else {
+    } else {
       status = INVALID;
     }
     json_free(protocol->old_content);
     protocol->old_content = content;
-  }
-  else {
+  } else {
     status = KNOWN;
     json_free(content);
   }
-  if(json_find_number(protocol->message, "id", &itmp) == 0) {
+  if (json_find_number(protocol->message, "id", &itmp) == 0) {
     deviceId = String((int)round(itmp));
-  }
-  else if (json_find_string(protocol->message, "id", &stmp) == 0) {
+  } else if (json_find_string(protocol->message, "id", &stmp) == 0) {
     deviceId = String(stmp);
   };
-  (callback)(String(protocol->id), String(protocol->old_content), status, protocol->repeats, deviceId);
+  (callback)(String(protocol->id), String(protocol->old_content), status,
+             protocol->repeats, deviceId);
 }
-
 
 String ESPiLight::pulseTrainToString(const uint16_t *codes, int length) {
   int i = 0, x = 0, match = 0;
-  int diff=0;
+  int diff = 0;
   int plstypes[MAX_PULSE_TYPES];
   String data("");
 
@@ -362,39 +350,39 @@ String ESPiLight::pulseTrainToString(const uint16_t *codes, int length) {
     return String("");
   }
 
-  for(x=0;x<MAX_PULSE_TYPES;x++) {
+  for (x = 0; x < MAX_PULSE_TYPES; x++) {
     plstypes[x] = 0;
   }
 
-  data.reserve(6+length);
-  //Serial.print("pulseTrainToString: ");
+  data.reserve(6 + length);
+  // Serial.print("pulseTrainToString: ");
   int p = 0;
   data += "c:";
-  for(i=0;i<length;i++) {
+  for (i = 0; i < length; i++) {
     match = 0;
-    for(x=0;x<MAX_PULSE_TYPES;x++) {
+    for (x = 0; x < MAX_PULSE_TYPES; x++) {
       /* We device these numbers by 10 to normalize them a bit */
-      diff = (plstypes[x]/50)-(codes[i]/50);
-      if((diff >= -2) && (diff <= 2)) {
-	/* Write numbers */
-	data += (char)('0'+((char)x));
-	match = 1;
-	break;
+      diff = (plstypes[x] / 50) - (codes[i] / 50);
+      if ((diff >= -2) && (diff <= 2)) {
+        /* Write numbers */
+        data += (char)('0' + ((char)x));
+        match = 1;
+        break;
       }
     }
-    if(match == 0) {
+    if (match == 0) {
       plstypes[p++] = codes[i];
-      data += (char)('0'+((char)(p-1)));
-      if(p>=MAX_PULSE_TYPES) {
-	Serial.println("too many pulse types");
-	return String("");
+      data += (char)('0' + ((char)(p - 1)));
+      if (p >= MAX_PULSE_TYPES) {
+        Serial.println("too many pulse types");
+        return String("");
       }
     }
   }
   data += ";p:";
-  for(i=0;i<p;i++) {
+  for (i = 0; i < p; i++) {
     data += plstypes[i];
-    if(i+1 < p) {
+    if (i + 1 < p) {
       data += ',';
     }
   }
@@ -402,43 +390,39 @@ String ESPiLight::pulseTrainToString(const uint16_t *codes, int length) {
   return data;
 }
 
-int ESPiLight::stringToPulseTrain(const String &data, uint16_t *codes, int maxlength) {
+int ESPiLight::stringToPulseTrain(const String &data, uint16_t *codes,
+                                  int maxlength) {
   int start = 0, end = 0, pulse_index;
   unsigned int i = 0;
   int plstypes[MAX_PULSE_TYPES];
 
-  for(i=0;i<MAX_PULSE_TYPES;i++) {
+  for (i = 0; i < MAX_PULSE_TYPES; i++) {
     plstypes[i] = 0;
   }
 
-  int scode = data.indexOf('c')+2;
-  int spulse = data.indexOf('p')+2;
-  if(scode > 0 && (unsigned) scode < data.length() &&
-     spulse > 0 && (unsigned) spulse < data.length()) {
+  int scode = data.indexOf('c') + 2;
+  int spulse = data.indexOf('p') + 2;
+  if (scode > 0 && (unsigned)scode < data.length() && spulse > 0 &&
+      (unsigned)spulse < data.length()) {
     int nrpulses = 0;
     start = spulse;
     end = data.indexOf(',', start);
-    while(end > 0) {
+    while (end > 0) {
       plstypes[nrpulses++] = data.substring(start, end).toInt();
-      start = end+1;
+      start = end + 1;
       end = data.indexOf(',', start);
     }
     end = data.indexOf(';', start);
-    if(end<0)
-      end = data.indexOf('@', start);
-    if(end<0)
-      return -2;
+    if (end < 0) end = data.indexOf('@', start);
+    if (end < 0) return -2;
     plstypes[nrpulses++] = data.substring(start, end).toInt();
 
     int codelen = 0;
-    for(i = scode; i < data.length(); i++) {
-      if((data[i] == ';') || (data[i] == '@'))
-	break;
-      if(i >= (unsigned) maxlength)
-	break;
+    for (i = scode; i < data.length(); i++) {
+      if ((data[i] == ';') || (data[i] == '@')) break;
+      if (i >= (unsigned)maxlength) break;
       pulse_index = data[i] - '0';
-      if((pulse_index < 0) || (pulse_index >= nrpulses))
-	return -3;
+      if ((pulse_index < 0) || (pulse_index >= nrpulses)) return -3;
       codes[codelen++] = plstypes[pulse_index];
     }
     return codelen;

--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -281,8 +281,8 @@ int ESPiLight::createPulseTrain(uint16_t *pulses, const String &protocol_id,
   return 0;
 }
 
-int ESPiLight::parsePulseTrain(uint16_t *pulses, uint8_t length) {
-  int matches = 0;
+unsigned int ESPiLight::parsePulseTrain(uint16_t *pulses, uint8_t length) {
+  unsigned int matches = 0;
   struct protocol_t *protocol = nullptr;
   struct protocols_t *pnode = used_protocols;
 

--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -58,9 +58,9 @@ void ESPiLight::initReceiver(byte inputPin) {
   }
 }
 
-int ESPiLight::receivePulseTrain(uint16_t *pulses) {
-  int i = 0;
-  int length = nextPulseTrainLength();
+uint8_t ESPiLight::receivePulseTrain(uint16_t *pulses) {
+  uint8_t i = 0;
+  uint8_t length = nextPulseTrainLength();
 
   if (length > 0) {
     volatile PulseTrain_t &pulseTrain = _pulseTrains[_avaiablePulseTrain];
@@ -73,7 +73,7 @@ int ESPiLight::receivePulseTrain(uint16_t *pulses) {
   return length;
 }
 
-int ESPiLight::nextPulseTrainLength() {
+uint8_t ESPiLight::nextPulseTrainLength() {
   return _pulseTrains[_avaiablePulseTrain].length;
 }
 
@@ -130,7 +130,7 @@ void ESPiLight::enableReceiver() { _enabledReceiver = true; }
 void ESPiLight::disableReceiver() { _enabledReceiver = false; }
 
 void ESPiLight::loop() {
-  int length = 0;
+  uint8_t length = 0;
   uint16_t pulses[MAXPULSESTREAMLENGTH];
 
   length = receivePulseTrain(pulses);
@@ -281,7 +281,7 @@ int ESPiLight::createPulseTrain(uint16_t *pulses, const String &protocol_id,
   return 0;
 }
 
-int ESPiLight::parsePulseTrain(uint16_t *pulses, int length) {
+int ESPiLight::parsePulseTrain(uint16_t *pulses, uint8_t length) {
   int matches = 0;
   struct protocol_t *protocol = nullptr;
   struct protocols_t *pnode = used_protocols;

--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -145,8 +145,8 @@ void ESPiLight::loop() {
 
 ESPiLight::ESPiLight(int8_t outputPin) {
   _outputPin = outputPin;
-  _callback = NULL;
-  _rawCallback = NULL;
+  _callback = nullptr;
+  _rawCallback = nullptr;
 
   if (_outputPin >= 0) {
     pinMode(_outputPin, OUTPUT);
@@ -228,7 +228,7 @@ int ESPiLight::send(const String &protocol, const String &json, int repeats) {
 
 int ESPiLight::createPulseTrain(uint16_t *pulses, const String &protocol_id,
                                 const String &content) {
-  struct protocol_t *protocol = NULL;
+  struct protocol_t *protocol = nullptr;
   struct protocols_t *pnode = used_protocols;
   int return_value = EXIT_FAILURE;
   JsonNode *message;
@@ -241,10 +241,10 @@ int ESPiLight::createPulseTrain(uint16_t *pulses, const String &protocol_id,
     return -2;
   }
 
-  while (pnode != NULL) {
+  while (pnode != nullptr) {
     protocol = pnode->listener;
 
-    if ((protocol->createCode != NULL) && (protocol_id == protocol->id) &&
+    if ((protocol->createCode != nullptr) && (protocol_id == protocol->id) &&
         (protocol->maxrawlen <= MAXPULSESTREAMLENGTH)) {
       Serial.print("protocol: ");
       Serial.print(protocol->id);
@@ -256,7 +256,7 @@ int ESPiLight::createPulseTrain(uint16_t *pulses, const String &protocol_id,
       json_delete(message);
       // delete message created by createCode()
       json_delete(protocol->message);
-      protocol->message = NULL;
+      protocol->message = nullptr;
 
       if (return_value == EXIT_SUCCESS) {
         Serial.println(" create Code succeded.");
@@ -273,14 +273,14 @@ int ESPiLight::createPulseTrain(uint16_t *pulses, const String &protocol_id,
 
 int ESPiLight::parsePulseTrain(uint16_t *pulses, int length) {
   int matches = 0;
-  struct protocol_t *protocol = NULL;
+  struct protocol_t *protocol = nullptr;
   struct protocols_t *pnode = used_protocols;
 
-  // Serial.println("piLightParsePulseTrain start");
-  while ((pnode != NULL) && (_callback != NULL)) {
+  // DebugLn("piLightParsePulseTrain start");
+  while ((pnode != nullptr) && (_callback != nullptr)) {
     protocol = pnode->listener;
 
-    if (protocol->parseCode != NULL && protocol->validate != NULL) {
+    if (protocol->parseCode != nullptr && protocol->validate != nullptr) {
       protocol->raw = pulses;
       protocol->rawlen = length;
 
@@ -303,22 +303,22 @@ int ESPiLight::parsePulseTrain(uint16_t *pulses, int length) {
           protocol->repeats = 0;
         }
 
-        protocol->message = NULL;
+        protocol->message = nullptr;
         protocol->parseCode();
-        if (protocol->message != NULL) {
+        if (protocol->message != nullptr) {
           matches++;
           protocol->repeats++;
 
           fire_callback(protocol, _callback);
 
           json_delete(protocol->message);
-          protocol->message = NULL;
+          protocol->message = nullptr;
         }
       }
     }
     pnode = pnode->next;
   }
-  if (_rawCallback != NULL) {
+  if (_rawCallback != nullptr) {
     (_rawCallback)(pulses, length);
   }
 
@@ -334,7 +334,7 @@ static void fire_callback(protocol_t *protocol, ESPiLightCallBack callback) {
   double itmp;
   char *stmp;
 
-  if ((protocol->repeats <= 1) || (protocol->old_content == NULL)) {
+  if ((protocol->repeats <= 1) || (protocol->old_content == nullptr)) {
     status = FIRST;
     json_free(protocol->old_content);
     protocol->old_content = content;

--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -40,10 +40,10 @@ volatile unsigned long ESPiLight::_lastChange =
     0;  // Timestamp of previous edge
 volatile uint8_t ESPiLight::_nrpulses = 0;
 
-unsigned int ESPiLight::minrawlen = 5;
-unsigned int ESPiLight::maxrawlen = MAXPULSESTREAMLENGTH;
-unsigned int ESPiLight::mingaplen = 5100;
-unsigned int ESPiLight::maxgaplen = 10000;
+uint8_t ESPiLight::minrawlen = 5;
+uint8_t ESPiLight::maxrawlen = MAXPULSESTREAMLENGTH;
+uint16_t ESPiLight::mingaplen = 5100;
+uint16_t ESPiLight::maxgaplen = 10000;
 
 static void fire_callback(protocol_t *protocol, ESPiLightCallBack callback);
 

--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -94,8 +94,8 @@ void ICACHE_RAM_ATTR ESPiLight::interruptHandler() {
     if (duration > MIN_PULSELENGTH) {
       if (duration < MAX_PULSELENGTH) {
         /* All codes are buffered */
-        codes[_nrpulses] = duration;
-        _nrpulses = (_nrpulses + 1) % MAXPULSESTREAMLENGTH;
+        codes[_nrpulses] = (uint16_t)duration;
+        _nrpulses = (uint8_t)((_nrpulses + 1) % MAXPULSESTREAMLENGTH);
         /* Let's match footers */
         if (duration > mingaplen) {
           // Debug('g');
@@ -396,14 +396,14 @@ String ESPiLight::pulseTrainToString(const uint16_t *codes,
       diff = (plstypes[x] / 50) - (codes[i] / 50);
       if ((diff >= -2) && (diff <= 2)) {
         /* Write numbers */
-        data += (char)('0' + ((char)x));
+        data += '0' + ((char)x);
         match = 1;
         break;
       }
     }
     if (match == 0) {
       plstypes[p++] = codes[i];
-      data += (char)('0' + ((char)(p - 1)));
+      data += '0' + ((char)(p - 1));
       if (p >= MAX_PULSE_TYPES) {
         DebugLn("too many pulse types");
         return String("");

--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -33,7 +33,7 @@ struct protocols_t *protocols = nullptr;
 struct protocols_t *used_protocols = nullptr;
 
 volatile PulseTrain_t ESPiLight::_pulseTrains[RECEIVER_BUFFER_SIZE];
-boolean ESPiLight::_enabledReceiver;
+bool ESPiLight::_enabledReceiver;
 volatile int ESPiLight::_actualPulseTrain = 0;
 int ESPiLight::_avaiablePulseTrain = 0;
 volatile unsigned long ESPiLight::_lastChange =
@@ -192,7 +192,7 @@ void ESPiLight::setPulseTrainCallBack(PulseTrainCallBack rawCallback) {
 
 void ESPiLight::sendPulseTrain(const uint16_t *pulses, int length,
                                int repeats) {
-  // boolean receiverState = _enabledReceiver;
+  // bool receiverState = _enabledReceiver;
   int r = 0, x = 0;
   if (_outputPin >= 0) {
     // disableReceiver()

--- a/src/ESPiLight.h
+++ b/src/ESPiLight.h
@@ -118,7 +118,7 @@ class ESPiLight {
   static uint16_t mingaplen;
   static uint16_t maxgaplen;
 
-  static String pulseTrainToString(const uint16_t *pulses, int length);
+  static String pulseTrainToString(const uint16_t *pulses, unsigned int length);
   static int stringToPulseTrain(const String &data, uint16_t *pulses,
                                 int maxlength);
 

--- a/src/ESPiLight.h
+++ b/src/ESPiLight.h
@@ -61,7 +61,7 @@ class ESPiLight {
   /**
    * Parse pulse train and fire callback
    */
-  int parsePulseTrain(uint16_t *pulses, uint8_t length);
+  unsigned int parsePulseTrain(uint16_t *pulses, uint8_t length);
 
   /**
    * Process receiver queue and fire callback

--- a/src/ESPiLight.h
+++ b/src/ESPiLight.h
@@ -106,6 +106,13 @@ class ESPiLight {
    */
   static void interruptHandler();
 
+  /**
+   * Limit the available protocols.
+   *
+   * This gets a json array of the protocol names that should be activated.
+   */
+  static void limitProtocols(const String &protos);
+
   static unsigned int minrawlen;
   static unsigned int maxrawlen;
   static unsigned int mingaplen;

--- a/src/ESPiLight.h
+++ b/src/ESPiLight.h
@@ -113,10 +113,10 @@ class ESPiLight {
    */
   static void limitProtocols(const String &protos);
 
-  static unsigned int minrawlen;
-  static unsigned int maxrawlen;
-  static unsigned int mingaplen;
-  static unsigned int maxgaplen;
+  static uint8_t minrawlen;
+  static uint8_t maxrawlen;
+  static uint16_t mingaplen;
+  static uint16_t maxgaplen;
 
   static String pulseTrainToString(const uint16_t *pulses, int length);
   static int stringToPulseTrain(const String &data, uint16_t *pulses,

--- a/src/ESPiLight.h
+++ b/src/ESPiLight.h
@@ -120,7 +120,7 @@ class ESPiLight {
 
   static String pulseTrainToString(const uint16_t *pulses, unsigned int length);
   static int stringToPulseTrain(const String &data, uint16_t *pulses,
-                                int maxlength);
+                                unsigned int maxlength);
 
   static int createPulseTrain(uint16_t *pulses, const String &protocol_id,
                               const String &json);

--- a/src/ESPiLight.h
+++ b/src/ESPiLight.h
@@ -39,7 +39,7 @@ typedef struct PulseTrain_t {
 typedef void (*ESPiLightCallBack)(const String &protocol, const String &message,
                                   int status, int repeats,
                                   const String &deviceID);
-typedef void (*PulseTrainCallBack)(const uint16_t *pulses, int length);
+typedef void (*PulseTrainCallBack)(const uint16_t *pulses, uint8_t length);
 
 class ESPiLight {
  public:
@@ -61,7 +61,7 @@ class ESPiLight {
   /**
    * Parse pulse train and fire callback
    */
-  int parsePulseTrain(uint16_t *pulses, int length);
+  int parsePulseTrain(uint16_t *pulses, uint8_t length);
 
   /**
    * Process receiver queue and fire callback
@@ -80,13 +80,13 @@ class ESPiLight {
    * Get last received PulseTrain.
    * Returns: length of PulseTrain or 0 if not avaiable
    */
-  static int receivePulseTrain(uint16_t *pulses);
+  static uint8_t receivePulseTrain(uint16_t *pulses);
 
   /**
    * Check if new PulseTrain avaiable.
    * Returns: 0 if no new PulseTrain avaiable
    */
-  static int nextPulseTrainLength();
+  static uint8_t nextPulseTrainLength();
 
   /**
    * Enable Receiver. No need to call enableReceiver() after initReceiver().

--- a/src/ESPiLight.h
+++ b/src/ESPiLight.h
@@ -23,21 +23,23 @@
 
 #define RECEIVER_BUFFER_SIZE 10
 
-#define MIN_PULSELENGTH       80
-#define MAX_PULSELENGTH       16000
-#define MAXPULSESTREAMLENGTH  255
+#define MIN_PULSELENGTH 80
+#define MAX_PULSELENGTH 16000
+#define MAXPULSESTREAMLENGTH 255
 
-#define MAX_PULSE_TYPES       16
+#define MAX_PULSE_TYPES 16
 
-enum PilightRepeatStatus_t {FIRST, INVALID, VALID, KNOWN};
+enum PilightRepeatStatus_t { FIRST, INVALID, VALID, KNOWN };
 
 typedef struct PulseTrain_t {
   uint16_t pulses[MAXPULSESTREAMLENGTH];
   uint8_t length;
 } PulseTrain_t;
 
-typedef void (*ESPiLightCallBack)(const String &protocol, const String &message, int status, int repeats, const String &deviceID);
-typedef void (*PulseTrainCallBack)(const uint16_t* pulses, int length);
+typedef void (*ESPiLightCallBack)(const String &protocol, const String &message,
+                                  int status, int repeats,
+                                  const String &deviceID);
+typedef void (*PulseTrainCallBack)(const uint16_t *pulses, int length);
 
 class ESPiLight {
  public:
@@ -49,12 +51,12 @@ class ESPiLight {
   /**
    * Transmit pulse train
    */
-  void sendPulseTrain(const uint16_t *pulses, int length, int repeats=10);
+  void sendPulseTrain(const uint16_t *pulses, int length, int repeats = 10);
 
   /**
    * Transmit Pilight json message
    */
-  int send(const String &protocol, const String &json, int repeats=10);
+  int send(const String &protocol, const String &json, int repeats = 10);
 
   /**
    * Parse pulse train and fire callback
@@ -97,8 +99,10 @@ class ESPiLight {
   static void disableReceiver();
 
   /**
-   * interruptHandler is called on every change in the input signal. If RcPilight::initReceiver is called
-   * with interrupt <0, you have to call interruptHandler() yourself. (Or use InterruptChain)
+   * interruptHandler is called on every change in the input signal. If
+   * RcPilight::initReceiver is called
+   * with interrupt <0, you have to call interruptHandler() yourself. (Or use
+   * InterruptChain)
    */
   static void interruptHandler();
 
@@ -108,9 +112,11 @@ class ESPiLight {
   static unsigned int maxgaplen;
 
   static String pulseTrainToString(const uint16_t *pulses, int length);
-  static int stringToPulseTrain(const String &data, uint16_t *pulses, int maxlength);
+  static int stringToPulseTrain(const String &data, uint16_t *pulses,
+                                int maxlength);
 
-  static int createPulseTrain(uint16_t *pulses, const String &protocol_id, const String &json);
+  static int createPulseTrain(uint16_t *pulses, const String &protocol_id,
+                              const String &json);
 
  private:
   ESPiLightCallBack _callback;
@@ -119,20 +125,22 @@ class ESPiLight {
 
   /**
    * Quasi-reset. Called when the current edge is too long or short.
-   * reset "promotes" the current edge as being the first edge of a new sequence.
+   * reset "promotes" the current edge as being the first edge of a new
+   * sequence.
    */
   static void resetReceiver();
 
   /**
    * Internal functions
    */
-  static boolean _enabledReceiver; // If true, monitoring and decoding is enabled. If false, interruptHandler will return immediately.
+  static boolean _enabledReceiver;  // If true, monitoring and decoding is
+                                    // enabled. If false, interruptHandler will
+                                    // return immediately.
   static volatile PulseTrain_t _pulseTrains[];
   static volatile int _actualPulseTrain;
   static int _avaiablePulseTrain;
-  static volatile unsigned long _lastChange; // Timestamp of previous edge
+  static volatile unsigned long _lastChange;  // Timestamp of previous edge
   static volatile uint8_t _nrpulses;
-
 };
 
 #endif

--- a/src/ESPiLight.h
+++ b/src/ESPiLight.h
@@ -140,9 +140,9 @@ class ESPiLight {
   /**
    * Internal functions
    */
-  static boolean _enabledReceiver;  // If true, monitoring and decoding is
-                                    // enabled. If false, interruptHandler will
-                                    // return immediately.
+  static bool _enabledReceiver;  // If true, monitoring and decoding is
+                                 // enabled. If false, interruptHandler will
+                                 // return immediately.
   static volatile PulseTrain_t _pulseTrains[];
   static volatile int _actualPulseTrain;
   static int _avaiablePulseTrain;

--- a/src/tools/aprintf.cpp
+++ b/src/tools/aprintf.cpp
@@ -16,12 +16,13 @@
   along with library. If not, see <http://www.gnu.org/licenses/>
 */
 
-#include <Arduino.h>
 #include "aprintf.h"
+#include <Arduino.h>
 
 void exit(int n) {
   Serial.print(F("EXIT: "));
-  Serial.println(n);    
+  Serial.println(n);
   ESP.restart();
-  while(true);
+  while (true)
+    ;
 }

--- a/src/tools/aprintf.h
+++ b/src/tools/aprintf.h
@@ -24,11 +24,11 @@
 #define fprintf(stream, args...) printf(args)
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 void exit(int n);
 #ifdef __cplusplus
-  }
+}
 #endif
 
-#endif //_APRINTF_H_
+#endif  //_APRINTF_H_

--- a/tests/test_parse/test_parse.ino
+++ b/tests/test_parse/test_parse.ino
@@ -12,7 +12,7 @@
 ESPiLight rf(-1);  //use -1 to disable transmitter
 
 // callback function. It is called on successfully received and parsed rc signal
-void rfRawCallback(const uint16_t* codes, int length) {
+void rfRawCallback(const uint16_t* codes, uint8_t length) {
   // print pulse lengths
   printPulseTran(codes, length);
   

--- a/tests/test_proto_limit/test_proto_limit.ino
+++ b/tests/test_proto_limit/test_proto_limit.ino
@@ -1,0 +1,64 @@
+/*
+ Basic ESPiLight protocol limiting
+
+ https://github.com/puuu/espilight
+*/
+
+#include <ESPiLight.h>
+
+#define PROTOCOL "elro_800_switch"
+#define JMESSAGE "{\"systemcode\":17,\"unitcode\":1,\"on\":1}"
+
+ESPiLight rf(-1);  //use -1 to disable transmitter
+
+// callback function. It is called on successfully received and parsed rc signal
+void rfCallback(const String &protocol, const String &message, int status, int repeats, const String &deviceID) {
+  Serial.print("parsed message [");
+  Serial.print(protocol); //protocoll used to parse
+  Serial.print("][");
+  Serial.print(deviceID); //value of id key in json message
+  Serial.print("] (");
+  Serial.print(status);
+  Serial.print(") ");
+  Serial.print(message); // message in json format
+  Serial.println();
+}
+
+void setup() {
+  Serial.begin(115200);
+  //set callback funktion
+  rf.setCallback(rfCallback);
+
+  int length = 0;
+  uint16_t pulses[MAXPULSESTREAMLENGTH];
+
+  // pulse train from ppilight json message
+  length = rf.createPulseTrain(pulses, PROTOCOL, JMESSAGE);
+
+  // parse pulse train multiple times
+  for (int i = 0; i < 5; i++) {
+    Serial.println();
+    Serial.print("Decoding turn ");
+    Serial.println(i);
+    Serial.println();
+    rf.parsePulseTrain(pulses, length);
+    delay(10);
+  }
+
+  // Limit the protocol
+  rf.limitProtocols("[\""  PROTOCOL  "\"]");
+
+  // parse pulse train multiple times
+  for (int i = 0; i < 5; i++) {
+    Serial.println();
+    Serial.print("Decoding turn ");
+    Serial.println(i);
+    Serial.println();
+    rf.parsePulseTrain(pulses, length);
+    delay(10);
+  }
+}
+
+void loop() {
+  //nothing
+}


### PR DESCRIPTION
This adds a simple .ino to test protocol filtering. The test generates a pulse train and parses it five rounds with and without the protocol support limited. The output on the serial console will differ between the two parts:

First part:
```
Decoding turn 0

parsed message [elro_400_switch][] (0) {"systemcode":14,"unitcode":15,"state":"on"}
parsed message [elro_800_contact][] (0) {"systemcode":17,"unitcode":1,"state":"opened"}
parsed message [elro_800_switch][] (0) {"systemcode":17,"unitcode":1,"state":"on"}
parsed message [ev1527][] (0) {"unitcode":700331,"state":"closed"}
parsed message [pollin][] (0) {"systemcode":17,"unitcode":1,"state":"on"}
```

Second part:
```
Decoding turn 0

parsed message [elro_800_switch][] (3) {"systemcode":17,"unitcode":1,"state":"on"}
```


This is based on PR #19.