### PR TITLE
Get protocol information out of the library

### DIFF
--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -526,3 +526,26 @@ void ESPiLight::limitProtocols(const String &protos) {
 
   json_delete(message);
 }
+
+static String protocols_to_array(protocols_t *pnode) {
+  JsonNode *message = json_mkarray();
+
+  while (pnode != nullptr) {
+    json_append_element(message, json_mkstring(pnode->listener->id));
+    pnode = pnode->next;
+  }
+
+  char *content = json_encode(message);
+  json_delete(message);
+
+  String ret(content);
+  json_free(content);
+
+  return ret;
+}
+
+String ESPiLight::availableProtocols() { return protocols_to_array(protocols); }
+
+String ESPiLight::enabledProtocols() {
+  return protocols_to_array(used_protocols);
+}

--- a/src/ESPiLight.h
+++ b/src/ESPiLight.h
@@ -114,6 +114,16 @@ class ESPiLight {
    */
   static void limitProtocols(const String &protos);
 
+  /**
+   * Return a json array containing all the available protocols.
+   */
+  static String availableProtocols();
+
+  /**
+   * Return an json array containing all the currently enabled protocols
+   */
+  static String enabledProtocols();
+
   static unsigned int minrawlen;
   static unsigned int maxrawlen;
   static unsigned int mingaplen;

--- a/tests/test_proto_limit/test_proto_limit.ino
+++ b/tests/test_proto_limit/test_proto_limit.ino
@@ -36,6 +36,12 @@ void setup() {
   // pulse train from ppilight json message
   length = rf.createPulseTrain(pulses, PROTOCOL, JMESSAGE);
 
+  // print available and enabled protocols
+  Serial.print("Available protocols: ");
+  Serial.println(rf.availableProtocols());
+  Serial.print("Enabled protocols: ");
+  Serial.println(rf.enabledProtocols());
+
   // parse pulse train multiple times
   for (int i = 0; i < 5; i++) {
     Serial.println();
@@ -49,6 +55,12 @@ void setup() {
   // Limit the protocol
   rf.limitProtocols("[\"" PROTOCOL "\"]");
 
+  // print available and enabled protocols
+  Serial.print("Available protocols: ");
+  Serial.println(rf.availableProtocols());
+  Serial.print("Enabled protocols: ");
+  Serial.println(rf.enabledProtocols());
+
   // parse pulse train multiple times
   for (int i = 0; i < 5; i++) {
     Serial.println();
@@ -61,6 +73,12 @@ void setup() {
 
   // Reset the filter
   rf.limitProtocols("[]");
+
+  // print available and enabled protocols
+  Serial.print("Available protocols: ");
+  Serial.println(rf.availableProtocols());
+  Serial.print("Enabled protocols: ");
+  Serial.println(rf.enabledProtocols());
 
   // parse pulse train multiple times
   for (int i = 0; i < 5; i++) {


### PR DESCRIPTION
This adds `ESPiLight::availableProtocols()` to get a list of all available protocols and  `ESPiLight::enabledProtocols()` to get a list of all enabled protocols. 

The list is given back as a json-array.

This makes it easier for implementations to show users what is possible to select for filters and what filters are maybe set.