### PR TITLE
place pilight log messages in PROGMEM

### DIFF
--- a/src/tools/aprintf.h
+++ b/src/tools/aprintf.h
@@ -21,7 +21,18 @@
 
 #include <stdio.h>
 
+#ifndef __cplusplus
+#include <pgmspace.h>
+#define FSTR(s)                            \
+  (__extension__({                         \
+    static const char __c[] PROGMEM = (s); \
+    &__c[0];                               \
+  }))
+#define printf(fmt, ...) printf(FSTR(fmt), ##__VA_ARGS__)
 #define fprintf(stream, args...) printf(args)
+#else
+#define fprintf(stream, args...) printf(args)
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This places the pilight log message string literals into PROGMEM. With
that they don't take up space in RAM. Testing with test_parse.ino gave
the following results for "free heap":
before: 26152 byte
after:  32936 byte
diff:    6784 byte

That is 71.5% free compared to the 56.8% of the 46032 byte free Heap
without pilight.