### PR TITLE
ESPiLight.cpp: fix infinite loop on unknown protocol.

### DIFF
--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -504,6 +504,7 @@ void ESPiLight::limitProtocols(const String &protos) {
   while (curr != nullptr) {
     if (!curr->tag == JSON_STRING) {
       DebugLn("Element is not a String");
+      curr = curr->next;
       continue;
     }
 
@@ -511,6 +512,7 @@ void ESPiLight::limitProtocols(const String &protos) {
     if (templ == nullptr) {
       Debug("Protocol not found: ");
       DebugLn(curr->string_);
+      curr = curr->next;
       continue;
     }
 


### PR DESCRIPTION
If we give the protocol limit method a protocol name that is not supported we enter an infinite loop - finally causing the watchdog to come after us.