### PR TITLE
Add repeats to string parsing, fix string error checking

### DIFF
--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -552,6 +552,25 @@ int ESPiLight::stringToPulseTrain(const String &data, uint16_t *codes,
   return length;
 }
 
+int ESPiLight::stringToRepeats(const String &data) {
+  // parsing (optional) repeats
+  int srepeat = data.indexOf('r') + 2;
+  if (srepeat < 2 || (unsigned)srepeat > data.length()) {
+    DebugLn("'r' not found in data string, or has no data");
+    return ERROR_INVALID_PULSETRAIN_MSG_R;
+  }
+  unsigned int start = (unsigned)srepeat;
+  int end = data.indexOf(';', start);
+  if (end < 0) {
+    end = data.indexOf('@', start);
+  }
+  if (end < 0) {
+    DebugLn("';' or '@' not found in data string");
+    return ERROR_INVALID_PULSETRAIN_MSG_END;
+  }
+  return data.substring(start, (unsigned)end).toInt();
+}
+
 void ESPiLight::limitProtocols(const String &protos) {
   if (!json_validate(protos.c_str())) {
     DebugLn("Protocol limit argument is not a valid json message!");

--- a/src/ESPiLight.h
+++ b/src/ESPiLight.h
@@ -150,6 +150,7 @@ class ESPiLight {
   static String pulseTrainToString(const uint16_t *pulses, size_t length);
   static int stringToPulseTrain(const String &data, uint16_t *pulses,
                                 size_t maxlength);
+  static int stringToRepeats(const String &data);
 
   static int createPulseTrain(uint16_t *pulses, const String &protocol_id,
                               const String &json);
@@ -169,6 +170,7 @@ class ESPiLight {
   static const int ERROR_INVALID_PULSETRAIN_MSG_P = -2;
   static const int ERROR_INVALID_PULSETRAIN_MSG_END = -3;
   static const int ERROR_INVALID_PULSETRAIN_MSG_TYPE = -4;
+  static const int ERROR_INVALID_PULSETRAIN_MSG_R = -5;
 
  private:
   ESPiLightCallBack _callback;

--- a/tests/test_parse/test_parse.ino
+++ b/tests/test_parse/test_parse.ino
@@ -27,7 +27,7 @@ void rfRawCallback(const uint16_t *codes, size_t length) {
 void rfCallback(const String &protocol, const String &message, int status,
                 size_t repeats, const String &deviceID) {
   Serial.print("parsed message [");
-  Serial.print(protocol);  // protocoll used to parse
+  Serial.print(protocol);  // protocol used to parse
   Serial.print("][");
   Serial.print(deviceID);  // value of id key in json message
   Serial.print("] (");
@@ -61,7 +61,7 @@ void setup() {
   Serial.print("Free heap: ");
   Serial.println(ESP.getFreeHeap());
 
-  // pulse train from ppilight json message
+  // pulse train from pilight json message
   length = rf.createPulseTrain(pulses, PROTOCOL, JMESSAGE);
   // print pulse lengths
   printPulseTrain(pulses, length);
@@ -90,6 +90,15 @@ void setup() {
     rf.parsePulseTrain(pulses, length);
     delay(10);
   }
+
+  // parse repeats in string
+  Serial.println();
+  data = "c:10011001100101010101100110011001100101011002;p:300,900,10200;r:17@";
+  Serial.print("string with repeats format: ");
+  Serial.println(data);
+  int repeats = rf.stringToRepeats(data);
+  Serial.print("number of repeats (should be 17): ");
+  Serial.println(repeats);
 }
 
 void loop() {


### PR DESCRIPTION
This adds support for specifying repeats in the pulse train string input to `stringToPulseTrain`, as supported by Pilight (e.g. `r:12`) [here](https://github.com/pilight/pilight/blob/staging/libs/pilight/hardware/433nano.lua) and [here](https://github.com/pilight/pilight-usb-nano/blob/master/pilight_usb_nano.c). This resolves #48.

It also fixes an existing bug with verifying the string for the `c:` and `p:` components which always produced false negatives.

I'm not sure about the argument passing and returning implementation I've used here, so I'm open to suggestions on how to do it better. So I've held off on modifying the following test and example that use it:

https://github.com/puuu/ESPiLight/blob/969ab14113f19859e43ce7bc4db69104b30833db/tests/test_parse/test_parse.ino#L75

https://github.com/puuu/ESPiLight/blob/969ab14113f19859e43ce7bc4db69104b30833db/examples/Transmit_Raw/Transmit_Raw.ino#L20-L23