### PR TITLE
Handle micros() overflow every 70 minutes

### DIFF
--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -231,29 +231,31 @@ void ICACHE_RAM_ATTR ESPiLight::interruptHandler() {
 
   if (pulseTrain.length == 0) {
     const unsigned long now = micros();
-    const unsigned int duration = now - _lastChange;
+    if (now > _lastChange) { // prevent overflow after 70 minutes
+      const unsigned long duration = now - _lastChange;
 
-    /* We first do some filtering (same as pilight BPF) */
-    if (duration > minpulselen) {
-      if (duration < maxpulselen) {
-        /* All codes are buffered */
-        codes[_nrpulses] = (uint16_t)duration;
-        _nrpulses = (uint8_t)((_nrpulses + 1) % MAXPULSESTREAMLENGTH);
-        /* Let's match footers */
-        if (duration > mingaplen) {
-          // Debug('g');
-          /* Only match minimal length pulse streams */
-          if (_nrpulses >= minrawlen && _nrpulses <= maxrawlen) {
-            // Debug(_nrpulses);
-            // Debug('l');
-            pulseTrain.length = _nrpulses;
-            _actualPulseTrain = (_actualPulseTrain + 1) % RECEIVER_BUFFER_SIZE;
+      /* We first do some filtering (same as pilight BPF) */
+      if (duration > minpulselen) {
+        if (duration < maxpulselen) {
+          /* All codes are buffered */
+          codes[_nrpulses] = (uint16_t)duration;
+          _nrpulses = (uint8_t)((_nrpulses + 1) % MAXPULSESTREAMLENGTH);
+          /* Let's match footers */
+          if (duration > mingaplen) {
+            // Debug('g');
+            /* Only match minimal length pulse streams */
+            if (_nrpulses >= minrawlen && _nrpulses <= maxrawlen) {
+              // Debug(_nrpulses);
+              // Debug('l');
+              pulseTrain.length = _nrpulses;
+              _actualPulseTrain = (_actualPulseTrain + 1) % RECEIVER_BUFFER_SIZE;
+            }
+            _nrpulses = 0;
           }
-          _nrpulses = 0;
         }
       }
-      _lastChange = now;
     }
+    _lastChange = now;
   } else {
     Debug("_!_");
   }
@@ -399,7 +401,7 @@ size_t ESPiLight::parsePulseTrain(uint16_t *pulses, uint8_t length) {
         }
 
         /* Reset # of repeats after a certain delay */
-        if ((protocol->second - protocol->first) > 500000) {
+        if (protocol->second < protocol->first || (protocol->second - protocol->first) > 500000) {
           protocol->repeats = 0;
         }
 
@@ -417,6 +419,7 @@ size_t ESPiLight::parsePulseTrain(uint16_t *pulses, uint8_t length) {
       }
     }
     pnode = pnode->next;
+    yield();
   }
   if (_rawCallback != nullptr) {
     (_rawCallback)(pulses, length);

--- a/src/ESPiLight.cpp
+++ b/src/ESPiLight.cpp
@@ -231,7 +231,7 @@ void ICACHE_RAM_ATTR ESPiLight::interruptHandler() {
 
   if (pulseTrain.length == 0) {
     const unsigned long now = micros();
-    if (now > _lastChange) { // prevent overflow after 70 minutes
+    if (now > _lastChange) {  // prevent overflow after 70 minutes
       const unsigned long duration = now - _lastChange;
 
       /* We first do some filtering (same as pilight BPF) */
@@ -248,7 +248,8 @@ void ICACHE_RAM_ATTR ESPiLight::interruptHandler() {
               // Debug(_nrpulses);
               // Debug('l');
               pulseTrain.length = _nrpulses;
-              _actualPulseTrain = (_actualPulseTrain + 1) % RECEIVER_BUFFER_SIZE;
+              _actualPulseTrain =
+                  (_actualPulseTrain + 1) % RECEIVER_BUFFER_SIZE;
             }
             _nrpulses = 0;
           }
@@ -401,7 +402,8 @@ size_t ESPiLight::parsePulseTrain(uint16_t *pulses, uint8_t length) {
         }
 
         /* Reset # of repeats after a certain delay */
-        if (protocol->second < protocol->first || (protocol->second - protocol->first) > 500000) {
+        if (protocol->second < protocol->first ||
+            (protocol->second - protocol->first) > 500000) {
           protocol->repeats = 0;
         }
 


### PR DESCRIPTION
Due to the long type of the micros() value, it will overflow and be resetted to 0 every 70 minutes. When using this value this should be handled to prevent invalid comparisons.